### PR TITLE
QOL improvements

### DIFF
--- a/private_key_file.go
+++ b/private_key_file.go
@@ -1,12 +1,13 @@
 package sshtunnel
 
 import (
+	"os"
+
 	"golang.org/x/crypto/ssh"
-	"io/ioutil"
 )
 
 func PrivateKeyFile(file string) ssh.AuthMethod {
-	buffer, err := ioutil.ReadFile(file)
+	buffer, err := os.ReadFile(file)
 	if err != nil {
 		return nil
 	}

--- a/ssh_tunnel.go
+++ b/ssh_tunnel.go
@@ -1,6 +1,7 @@
 package sshtunnel
 
 import (
+	"errors"
 	"io"
 	"net"
 
@@ -12,16 +13,17 @@ type logger interface {
 }
 
 type SSHTunnel struct {
-	Local                 *Endpoint
-	Server                *Endpoint
-	Remote                *Endpoint
-	Config                *ssh.ClientConfig
-	Log                   logger
-	Conns                 []net.Conn
-	SvrConns              []*ssh.Client
-	MaxConnectionAttempts int
-	isOpen                bool
-	close                 chan interface{}
+	Local                   *Endpoint
+	Server                  *Endpoint
+	Remote                  *Endpoint
+	Config                  *ssh.ClientConfig
+	Log                     logger
+	Conns                   []net.Conn
+	SvrConns                []*ssh.Client
+	MaxConnectionAttempts   int
+	CloseLocalOnDialFailure bool
+	isOpen                  bool
+	close                   chan interface{}
 }
 
 func (tunnel *SSHTunnel) logf(fmt string, args ...interface{}) {
@@ -38,11 +40,23 @@ func newConnectionWaiter(listener net.Listener, c chan net.Conn) {
 	c <- conn
 }
 
-func (tunnel *SSHTunnel) Start() error {
-	listener, err := net.Listen("tcp", tunnel.Local.String())
+func (t *SSHTunnel) Listen() (net.Listener, error) {
+	return net.Listen("tcp", t.Local.String())
+}
+
+func (t *SSHTunnel) Start() error {
+	listener, err := t.Listen()
 	if err != nil {
+		t.logf("listen error: %s", err)
 		return err
 	}
+	defer listener.Close()
+
+	return t.Serve(listener)
+}
+
+func (tunnel *SSHTunnel) Serve(listener net.Listener) error {
+
 	tunnel.isOpen = true
 	tunnel.Local.Port = listener.Addr().(*net.TCPAddr).Port
 
@@ -61,7 +75,7 @@ func (tunnel *SSHTunnel) Start() error {
 
 		c := make(chan net.Conn)
 		go newConnectionWaiter(listener, c)
-		tunnel.logf("listening for new connections...")
+		tunnel.logf("listening for new connections on %s:%d...", tunnel.Local.Host, tunnel.Local.Port)
 
 		select {
 		case <-tunnel.close:
@@ -69,7 +83,7 @@ func (tunnel *SSHTunnel) Start() error {
 			tunnel.isOpen = false
 		case conn := <-c:
 			tunnel.Conns = append(tunnel.Conns, conn)
-			tunnel.logf("accepted connection")
+			tunnel.logf("accepted connection from %s", conn.RemoteAddr().String())
 			go tunnel.forward(conn)
 		}
 	}
@@ -79,6 +93,10 @@ func (tunnel *SSHTunnel) Start() error {
 		tunnel.logf("closing the netConn (%d of %d)", i+1, total)
 		err := conn.Close()
 		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				// no need to report on closed connections
+				continue
+			}
 			tunnel.logf(err.Error())
 		}
 	}
@@ -90,10 +108,7 @@ func (tunnel *SSHTunnel) Start() error {
 			tunnel.logf(err.Error())
 		}
 	}
-	err = listener.Close()
-	if err != nil {
-		return err
-	}
+
 	tunnel.logf("tunnel closed")
 	return nil
 }
@@ -112,8 +127,18 @@ func (tunnel *SSHTunnel) forward(localConn net.Conn) {
 
 			if attemptsLeft <= 0 {
 				tunnel.logf("server dial error: %v: exceeded %d attempts", err, tunnel.MaxConnectionAttempts)
+
+				if tunnel.CloseLocalOnDialFailure {
+					if err := localConn.Close(); err != nil {
+						tunnel.logf("failed to close local connection: %v", err)
+						return
+					}
+					tunnel.logf("dial failed, closing local connection: %v", err)
+				}
+
 				return
 			}
+			tunnel.logf("server dial error: %v: attempt %d/%d", err, tunnel.MaxConnectionAttempts-attemptsLeft, tunnel.MaxConnectionAttempts)
 		} else {
 			break
 		}
@@ -137,13 +162,10 @@ func (tunnel *SSHTunnel) forward(localConn net.Conn) {
 	}
 	go copyConn(localConn, remoteConn)
 	go copyConn(remoteConn, localConn)
-
-	return
 }
 
 func (tunnel *SSHTunnel) Close() {
 	tunnel.close <- struct{}{}
-	return
 }
 
 // NewSSHTunnel creates a new single-use tunnel. Supplying "0" for localport will use a random port.


### PR DESCRIPTION
- move to os from ioutil
- add some more verbose logs
- add a Listen/Serve pattern, and wrap `Start` around that, to allow generating the listener without
- flag to immediately close connections that fail to dial